### PR TITLE
Feat: Add Conditional Cleanup

### DIFF
--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.28
+version: 1.1.29
 appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator-chart/templates/webhook-cleanup-job.yaml
@@ -1,4 +1,10 @@
-{{ if .Values.webhook.enable }}
+# Get service account if exists
+{{- $serviceAccountNamespace := default .Release.Namespace .Values.sparkJobNamespace}}
+{{- $serviceAccountName := include "spark-operator.serviceAccountName" . }}
+{{- $serviceAccount := (lookup "v1" "ServiceAccount" $serviceAccountNamespace $serviceAccountName )}}
+
+# Only run this job if service account exists. Otherwise this job will fail and prevent any other hook from running.
+{{ if and .Values.webhook.enable $serviceAccount }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
This prevents the cleanup job from attempting to run if a service account does not exist for it. If the cleanup job runs without a service account, the job will fail and prevent other pre-install/pre-upgrade hooks from running, critically the init hook, which prevents near anything from working. 

This occurs in argo deployments, where a pre-install and pre-upgrade hook is treated the same, and because the init hook has a higher weight than the cleanup hook, the cleanup hook runs faster and everything gets stuck. 